### PR TITLE
Update GitHub Actions workflows to schedule star fetching on Sundays and add update stars job

### DIFF
--- a/.github/workflows/fetch-stars.yml
+++ b/.github/workflows/fetch-stars.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 3 * * *" # Todos los días a las 3am UTC
+    - cron: "0 3 * * 0" # Todos los domingos a las 3am UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -1,0 +1,35 @@
+name: Update Stars
+
+on:
+  push:
+    paths:
+      - 'data/stars.json'
+  schedule:
+    - cron: '0 */12 * * *'  # Run every 12 hours
+
+jobs:
+  update-stars:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes in stars.json
+        id: check_changes
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep -q "data/stars.json"; then
+            echo "stars_json_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "stars_json_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy to GitHub Pages
+        if: steps.check_changes.outputs.stars_json_changed == 'true'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          force_orphan: true

--- a/scripts/githubStars.js
+++ b/scripts/githubStars.js
@@ -35,18 +35,23 @@ async function updateGitHubStars() {
 
     // Check if this is a star count link
     const isStarCountLink = link.textContent.match(/^\d[\d,\.]*k?\s?stars?$/i);
+    // Check if this is a GitHub link
+    const isGitHubLink = link.textContent.trim() === "GitHub";
 
     if (isStarCountLink) {
       // This is a star count link, update its text
       link.textContent = `${formattedStars} stars`;
+    } else if (isGitHubLink) {
+      // This is a GitHub link, replace text with star count
+      link.textContent = `⭐ ${formattedStars} stars`;
     } else {
       // This is a regular link, handle inline star count
       let hasExistingStars = false;
 
       // Remove any existing star spans
-      const existingStarSpans = link.querySelectorAll('span');
-      existingStarSpans.forEach(span => {
-        if (span.textContent.includes('⭐')) {
+      const existingStarSpans = link.querySelectorAll("span");
+      existingStarSpans.forEach((span) => {
+        if (span.textContent.includes("⭐")) {
           span.remove();
           hasExistingStars = true;
         }
@@ -54,15 +59,18 @@ async function updateGitHubStars() {
 
       // Check for and remove any inline star text
       for (const node of link.childNodes) {
-        if (node.nodeType === Node.TEXT_NODE && starTextRegex.test(node.textContent)) {
-          node.textContent = node.textContent.replace(starTextRegex, '').trim();
+        if (
+          node.nodeType === Node.TEXT_NODE &&
+          starTextRegex.test(node.textContent)
+        ) {
+          node.textContent = node.textContent.replace(starTextRegex, "").trim();
           hasExistingStars = true;
         }
       }
 
       // Only add star count if there was one before
       if (hasExistingStars) {
-        const span = document.createElement('span');
+        const span = document.createElement("span");
         span.textContent = ` ${newStarText}`;
         link.appendChild(span);
       }


### PR DESCRIPTION
This pull request introduces changes to GitHub Actions workflows and a JavaScript script to improve automation and user experience. The key updates include modifying the schedule for fetching stars, adding a new workflow to update stars, and enhancing the logic for updating GitHub star counts in the UI.

### Workflow Updates:
* **Modified fetch-stars schedule**: Updated the cron schedule in `.github/workflows/fetch-stars.yml` to run every Sunday at 3 AM UTC instead of daily.
* **Added update-stars workflow**: Introduced a new workflow in `.github/workflows/update-stars.yml` to trigger on changes to `data/stars.json` and on a 12-hour schedule. It checks for changes in the file and deploys updates to GitHub Pages if needed.

### JavaScript Enhancements:
* **Improved star count updates**: Enhanced the `updateGitHubStars` function in `scripts/githubStars.js` to handle GitHub links explicitly, replacing their text with the formatted star count. Also refined logic for managing inline star counts and existing star spans.