### PR TITLE
Add Mini-Tools.uk Upload to Images Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,6 +1292,7 @@ Comparison of major documentation tools:
 
 - [Cloudinary](https://cloudinary.com) is a cloud-based image and video management solution. ⭐ [GitHub](https://github.com/cloudinary)
 - [imgur](https://imgur.com) is a free image hosting service.
+- [Mini-Tools.uk Upload](https://mini-tools.uk/upload) is a free image hosting and image-to-link page for quickly uploading images and copying Direct URL, Markdown, HTML or BBCode links for README files, docs, forums, support tickets and temporary screenshot sharing.
 - [Imgix](https://www.imgix.com) is a real-time image processing and delivery service.
 - [Cloudimage](https://www.cloudimage.io) is a smart image management solution. ⭐ [GitHub](https://github.com/scaleflex)
 - [Imagekit](https://imagekit.io) is a real-time image optimization and delivery service.


### PR DESCRIPTION
Hi, self-recommending a small free image hosting page I maintain: https://mini-tools.uk/upload. It is a single-purpose upload image and get URL page that returns a direct image URL plus Markdown, HTML and BBCode snippets, useful for README images, Markdown docs, forum posts, support tickets and temporary screenshot sharing. I added it only under Images Hosting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Mini-Tools.uk Upload to the Images Hosting resources list, featuring free image hosting with support for Direct URL, Markdown, HTML, and BBCode link formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->