### PR TITLE
Add Markstream to Frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A collection of links to **free resources** and **tools** for developers. It inc
 
 # Frontend
 
-- [Markstream](https://markstream.simonhe.me/) - Markstream is a multi-framework streaming Markdown renderer for AI chat interfaces. It renders incomplete token streams with low-jitter updates and supports Vue/Nuxt, React/Next.js/Remix, Svelte, Angular, and Vue 2, with Mermaid, KaTeX, Shiki, Monaco, safe HTML, SSR, and custom components.
+- [Markstream](https://markstream.simonhe.me/) ([GitHub](https://github.com/Simon-He95/markstream-vue)) - Free, MIT-licensed streaming Markdown renderer for AI chat interfaces (~2.7k GitHub stars). Supports Vue/Nuxt, React/Next.js/Remix, Svelte, Angular, and Vue 2, with Mermaid, KaTeX, Shiki, Monaco, safe HTML, SSR, and custom components. Tags: markdown, streaming, ai-chat, vue, react, svelte, angular.
 
 [Frontend dev bookmarks](https://github.com/dypsilon/frontend-dev-bookmarks) - Manually curated collection of resources for frontend web developers.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ A collection of links to **free resources** and **tools** for developers. It inc
 
 # Frontend
 
+- [Markstream](https://markstream.simonhe.me/) - Markstream is a multi-framework streaming Markdown renderer for AI chat interfaces. It renders incomplete token streams with low-jitter updates and supports Vue/Nuxt, React/Next.js/Remix, Svelte, Angular, and Vue 2, with Mermaid, KaTeX, Shiki, Monaco, safe HTML, SSR, and custom components.
+
 [Frontend dev bookmarks](https://github.com/dypsilon/frontend-dev-bookmarks) - Manually curated collection of resources for frontend web developers.
 
 ## Dashboards and Admin Panels


### PR DESCRIPTION
## Related Issues

Closes #287

## Changes Proposed

Adds Markstream to the Frontend section. Markstream is a free, MIT-licensed streaming Markdown renderer for AI chat interfaces, with public documentation and source code.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] New/update resource

## Requirements

- [x] It has a free tier not just a free trial
- [x] Pricing information is clearly visible without signup or phone calls
- [x] The resource mentions what is free
- [x] The resource is not already present in the list

Project: https://markstream-vue.simonhe.me/
Source: https://github.com/Simon-He95/markstream-vue