### PR TITLE
Add Zero Dollar Domains to Free Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1272,6 +1272,7 @@ Comparison of major documentation tools:
 - [Freenom](https://www.freenom.com) is a domain name registrar that provides free domain registration services.
 - [JS.org](https://js.org) is a free domain dedicated to JavaScript and its awesome community. ⭐ [5.1k stars](https://github.com/js-org/js.org)
 - [is-a.dev](https://is-a.dev) is a service that allows developers to get a sweet-looking .is-a.dev subdomain for their personal websites. ⭐ [2.5k stars](https://github.com/is-a-dev/register)
+- [Zero Dollar Domains](https://arynjennen1989-stack.github.io/) is a catalog of programs that still give a $0 domain or subdomain (eu.org, is-a.dev, DuckDNS, and others), plus a live RDAP hunter for unused cheap TLDs.
 
 ### Domain tools
 

--- a/README.md
+++ b/README.md
@@ -1272,7 +1272,7 @@ Comparison of major documentation tools:
 - [Freenom](https://www.freenom.com) is a domain name registrar that provides free domain registration services.
 - [JS.org](https://js.org) is a free domain dedicated to JavaScript and its awesome community. ⭐ [5.1k stars](https://github.com/js-org/js.org)
 - [is-a.dev](https://is-a.dev) is a service that allows developers to get a sweet-looking .is-a.dev subdomain for their personal websites. ⭐ [2.5k stars](https://github.com/is-a-dev/register)
-- [Zero Dollar Domains](https://arynjennen1989-stack.github.io/) is a catalog of programs that still give a $0 domain or subdomain (eu.org, is-a.dev, DuckDNS, and others), plus a live RDAP hunter for unused cheap TLDs.
+- [Zero Dollar Domains](https://arynjennen1989-stack.github.io/) is a catalog of programs that still give a $0 domain or subdomain (eu.org, is-a.dev, DuckDNS, and others), plus a live RDAP hunter for unused TLDs with low first-year prices, not forever-free registration.
 
 ### Domain tools
 


### PR DESCRIPTION
Adds [Zero Dollar Domains](https://arynjennen1989-stack.github.io/) under **Free Domain**, next to js.org and is-a.dev.

It is a catalog of programs that still give a $0 domain or subdomain, plus a live RDAP hunter for unused cheap TLD names. Forever-free vs year-1 cheap is labeled honestly. Not an expired-.com scraper.

Happy to move it under Domain tools instead if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the Zero Dollar Domains resource description to specify that it targets unused TLDs with low first-year prices and does not cover forever-free registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->