### PR TITLE
Add FrontendAtlas Essential 60 to interview resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1468,6 +1468,7 @@ Internet Archive is a non-profit library of millions of free books, movies, soft
 - [Coding Interview University](https://github.com/jwasham/coding-interview-university) is a complete computer science study plan to become a software engineer. ⭐ [280k stars](https://github.com/jwasham/coding-interview-university)
 - [Doppler](https://www.doppler.com) is a curated **awesome list of lists of interview questions** 🎓⭐ [65k stars](https://github.com/DopplerHQ/awesome-interview-questions)
 - [Frontend Interview Questions](https://www.frontendinterviewquestions.com/interview-questions) is a collection of **interview questions** for **frontend developers**.
+- [FrontendAtlas Essential 60](https://frontendatlas.com/interview-questions/essential) is a publicly viewable shortlist of 60 frontend interview prompts covering JavaScript utilities, UI coding, accessibility, and frontend system design, with 7-, 14-, and 30-day practice guidance. Some linked exercises require Premium. 💲💲
 - [Tech Interview Handbook](https://www.techinterviewhandbook.org) is a free curated interview preparation materials for busy people. Brought to you by the author of Blind 75. ⭐ [113k stars](https://github.com/yangshun/tech-interview-handbook)
 
 ## Competitive programming


### PR DESCRIPTION
## Related Issues

None.

## Changes Proposed

Adds FrontendAtlas Essential 60 to **Career Development → Interviews**. The public page groups 60 frontend interview prompts across JavaScript utilities, UI coding, accessibility, and frontend system design, with 7-, 14-, and 30-day practice guidance.

Full disclosure: I am the creator of FrontendAtlas. The shortlist page is publicly viewable; some linked exercises require Premium, which the new entry states explicitly and marks with 💲💲. No paid or reciprocal placement is requested.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] New/update resource

## Requirements

- [x] It has a free tier not just a free trial
- [ ] Pricing information is clearly visible without signup or phone calls
- [x] The resource mentions what is free
- [x] The resource is not already present in the list

Pricing note: the public pricing page currently shows checkout as unavailable, so I have left that requirement unchecked rather than overstate the current status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FrontendAtlas Essential 60 to the Interviews resources list.
  * Included a link to frontend interview prompts and practice guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->